### PR TITLE
v1.44 - Debug logging and endpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,6 @@ jobs:
     - name: compile the frontend
       run: |
         bundle exec rake frontend_build
-    - name: check for TODOs
+    - name: check for TODO string instances
       run: |
-        git ls-files frontend backend | xargs grep -Ii todo | wc -l | xargs ruby -e 'exit ARGV[0].to_i == 0'
+        git ls-files | grep -v test\.yml | xargs grep -Ii todo | wc -l | xargs ruby -e 'exit ARGV[0].to_i == 0'

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ backend/gnuplex.sqlite3
 backend/public/*
 backend/static/*
 .bundle
+gnuplex.sqlite3
 node_modules
 .project.vim
-tmp/*
-vendor
+tmp
+vendor.ruby-lsp

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,3 @@
 http://localhost:50000 {
-	reverse_proxy /api/* localhost:40000
-	reverse_proxy localhost:5173
+	reverse_proxy * localhost:40000
 }

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ gnuplex -upgrade
 
 # Releases
 
-| Version          | Date                           | Details                                                |
-| ---------------- | ------------------------------ | ------------------------------------------------------ |
-| 1.41             | 2025-02-09                     | Better MPV crash handling, style touchups, Tailwind 4. |
-| 1.3              | 2024-12-07                     | Dark mode, React 19.                                   |
-| 1.2              | 2024-11-30                     | Hotfix.                                                |
-| 1.1              | 2024-11-30                     | Subtitle selection.                                    |
-| 1.0 Seaside Park | 2024-11-16                     | v1.0!!                                                 |
-| 0.99             | 2024-10-20                     | v1.0, beta.                                            |
-| Alpha stages     | ~Christmas 2022 - October 2024 | See commits before 1.0 release.                        |
+| Version          | Date                           | Details                                                                              |
+| ---------------- | ------------------------------ | ------------------------------------------------------------------------------------ |
+| 1.44             | 2025-03-22                     | More debug logging, the /build webpage.                                                                                    |
+| 1.41 - 1.43      | 2025-02 - 2025-03              | Better crash handling, style touchups, dependency updates, many needed improvements. |
+| 1.3              | 2024-12-07                     | Dark mode, React 19.                                                                 |
+| 1.2              | 2024-11-30                     | Hotfix.                                                                              |
+| 1.1              | 2024-11-30                     | Subtitle selection.                                                                  |
+| 1.0 Seaside Park | 2024-11-16                     | v1.0!!                                                                               |
+| 0.99             | 2024-10-20                     | v1.0, beta.                                                                          |
+| Alpha stages     | ~Christmas 2022 - October 2024 | See commits before 1.0 release.                                                      |

--- a/Rakefile
+++ b/Rakefile
@@ -3,28 +3,48 @@ require "fileutils"
 
 desc "start development server"
 task :dev do
-  sh "bun i --cwd frontend"
-  FileUtils.mkdir_p "tmp"
-  caddy = Process.spawn "caddy run"
-  frontend = Process.spawn "bun run --cwd frontend dev"
-  backend = Process.spawn "go run -C backend . -verbose"
-  Signal.trap("TERM") {
-    [caddy, frontend, backend].each { |p| Process.kill "HUP", p }
-    exit
-  }
-  [caddy, frontend, backend].each { |p| Process.waitpid p }
+  Dir.chdir(__dir__) do
+    sh "bun i --cwd frontend"
+    FileUtils.mkdir_p "tmp"
+    caddy = Process.spawn "caddy run"
+    frontend = Process.spawn "bun run --cwd frontend dev"
+    backend = Process.spawn "go run -C backend . -verbose"
+    Signal.trap("TERM") {
+      [caddy, frontend, backend].each { |p| Process.kill "HUP", p }
+      exit
+    }
+    [caddy, frontend, backend].each { |p| Process.waitpid p }
+  end
+end
+
+desc "start development server (compiled build)"
+task dev_compiled: [:build] do
+  Dir.chdir(__dir__) do
+    FileUtils.mkdir_p "tmp"
+    caddy = Process.spawn "caddy run"
+    backend = Process.spawn "./backend/bin/gnuplex -verbose -static_files ./backend/static"
+    Signal.trap("TERM") {
+      [caddy, backend].each { |p| Process.kill "HUP", p }
+      exit
+    }
+    [caddy, backend].each { |p| Process.waitpid p }
+  end
 end
 
 desc "build frontend"
 task :frontend_build do
-  sh "bun i --cwd frontend"
-  sh "bun run --cwd frontend build"
+  Dir.chdir(__dir__) do
+    sh "bun i --cwd frontend"
+    sh "bun run --cwd frontend build"
+  end
 end
 
 desc "build backend go code"
 task :go_build do
-  target = ENV.fetch("TARGET", "bin/gnuplex")
-  sh "go", "build", "-C", "backend", "-o", target, "-ldflags", "-X main.SourceHash=" + source_hash, "."
+  Dir.chdir(__dir__) do
+    target = ENV.fetch("TARGET", "bin/gnuplex")
+    sh "go", "build", "-C", "backend", "-o", target, "-ldflags", "-X main.SourceHash=" + source_hash, "."
+  end
 end
 
 desc "build backend (CI use only)"
@@ -39,9 +59,11 @@ task build: [:frontend_build, :go_build]
 
 desc "is the go build current?"
 task :go_build_current do
-  exit 1 unless File.exist? File.join(__dir__, "backend/bin/gnuplex")
-  build_hash = `./backend/bin/gnuplex -source_hash`.strip
-  exit source_hash == build_hash
+  Dir.chdir(__dir__) do
+    exit 1 unless File.exist? File.join(__dir__, "backend/bin/gnuplex")
+    build_hash = `./backend/bin/gnuplex -source_hash`.strip
+    exit source_hash == build_hash
+  end
 end
 
 desc "print go source code hash"
@@ -50,5 +72,7 @@ task :go_source_hash do
 end
 
 def source_hash
-  `find backend -type f -name '*.go' -or -name 'go*' | xargs sha512sum | cut -d ' ' -f 1 | sort | sha512sum | cut -d ' ' -f 1`.strip
+  Dir.chdir(__dir__) do
+    `find backend -type f -name '*.go' | sort | while read i; do echo "$i"; cat "$i"; done | sha256sum | cut -d ' ' -f 1`.strip
+  end
 end

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,0 @@
-# TODO
-
-- more debug logging. e.g. countdown of times until restart. eventual goal: make
-  it easier to isolate source of crash, see what's causing crash
-- `/build` endpoint with build info. eventual goal: every little change
-  shouldn't need to be a version bump. and auto-update

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# TODO
+
+- more debug logging. e.g. countdown of times until restart. eventual goal: make
+  it easier to isolate source of crash, see what's causing crash
+- `/build` endpoint with build info. eventual goal: every little change
+  shouldn't need to be a version bump. and auto-update

--- a/backend/consts/consts.go
+++ b/backend/consts/consts.go
@@ -1,5 +1,5 @@
 package consts
 
 const (
-	GNUPlexVersion = "1.43 Seaside Park"
+	GNUPlexVersion = "1.44 Seaside Park"
 )

--- a/backend/gnuplex/gnuplex.go
+++ b/backend/gnuplex/gnuplex.go
@@ -21,12 +21,12 @@ type GNUPlex struct {
 }
 
 // Initialize a GNUPlex instance.
-func Init(wg *sync.WaitGroup, verbose bool, dbPath, staticFiles string, port int) (*GNUPlex, error) {
+func Init(wg *sync.WaitGroup, verbose bool, dbPath, staticFiles string, port int, sourceHash string) (*GNUPlex, error) {
 	// HTTP backend
 	gnuplex := new(GNUPlex)
 	gnuplex.Router = gin.Default()
 	gnuplex.Router.SetTrustedProxies(nil)
-	gnuplex.InitWebEndpoints(verbose, staticFiles)
+	gnuplex.InitWebEndpoints(verbose, staticFiles, sourceHash)
 	// MPV instance
 	mpv, err := mpv.Init(wg, verbose)
 	if err != nil {

--- a/backend/gnuplex/webEndpoints.go
+++ b/backend/gnuplex/webEndpoints.go
@@ -42,7 +42,7 @@ type SubBody struct {
 }
 
 // Initialize the web server's HTTP Endpoints
-func (gnuplex *GNUPlex) InitWebEndpoints(prod bool, staticFiles string) {
+func (gnuplex *GNUPlex) InitWebEndpoints(prod bool, staticFiles, sourceHash string) {
 	gnuplex.Router.GET("/", func(c *gin.Context) {
 		c.Redirect(http.StatusMovedPermanently, "/home")
 	})
@@ -52,6 +52,9 @@ func (gnuplex *GNUPlex) InitWebEndpoints(prod bool, staticFiles string) {
 	gnuplex.Router.Static("/home", staticFiles)
 	gnuplex.Router.GET("/api/version", func(c *gin.Context) {
 		c.JSON(http.StatusOK, consts.GNUPlexVersion)
+	})
+	gnuplex.Router.GET("/api/source_hash", func(c *gin.Context) {
+		c.JSON(http.StatusOK, sourceHash)
 	})
 	gnuplex.Router.POST("/api/play", func(c *gin.Context) {
 		if err := gnuplex.MPV.Play(); err != nil {

--- a/backend/main.go
+++ b/backend/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/reugn/go-quartz/quartz"
 )
 
+// Set by Ldflag at compile time (see Rakefile's go_build task)
 var SourceHash string
 
 func main() {
@@ -55,7 +56,7 @@ func main() {
 	// Main daemon setup
 	var wg sync.WaitGroup
 	wg.Add(1)
-	server, err := server.Init(&wg, (!*prod) || (*verbose), *dbPath, *staticFiles, *port)
+	server, err := server.Init(&wg, (!*prod) || (*verbose), *dbPath, *staticFiles, *port, SourceHash)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -65,19 +66,19 @@ func main() {
 	defer cancel()
 	sched, err := quartz.NewStdScheduler()
 	if err != nil {
-		log.Fatal("Cron init failure", err)
+		log.Fatal("c98500e1-42f4-4c5d-ad2c-cedd4e4712b0 Failed to initialize cron scheduler", err)
 	}
 	sched.Start(ctx)
 	scanLibTrigger, err := quartz.NewCronTrigger("0 15 10 * * ?")
 	if err != nil {
-		log.Fatal("CronTrigger init failure", err)
+		log.Fatalln("9d9da752-4415-48ce-beec-0d8c703dd012 Failed to initialize cron scheduler", err)
 	}
 	scanLibJob := job.NewFunctionJob(func(_ context.Context) (int, error) {
 		return 0, server.ScanLib()
 	})
 	err = sched.ScheduleJob(quartz.NewJobDetail(scanLibJob, quartz.NewJobKey("scanlib")), scanLibTrigger)
 	if err != nil {
-		log.Fatal("Scheduler init failure", err)
+		log.Fatalln("638eded7-2ad6-45b5-a13f-a99ad4642ff5 Failed to initialize cron scheduler", err)
 	}
 	// Main execution
 	wg.Wait()
@@ -89,7 +90,7 @@ func upgradeGNUPlex(exe string) {
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
 	if err != nil {
-		log.Fatalln("fail", err)
+		log.Fatalln("f0ac0db2-c77e-4bb4-94b4-7b98931d6379 Failed to upgrade GNUPlex", err)
 	} else {
 		fmt.Println("Successfully upgraded! Now run `systemctl --user restart gnuplex`.")
 		os.Exit(0)

--- a/backend/mpv/mpv.go
+++ b/backend/mpv/mpv.go
@@ -25,7 +25,7 @@ type MPV struct {
 
 func (mpv *MPV) restartProcess() error {
 	if mpv.RestartCount >= 10 {
-		return errors.New("reached restart limit, 10")
+		return errors.New("4b367530-abab-4964-a093-72f78cf523f2 reached limit of MPV restarts (10)")
 	}
 	mpv.RestartCount += 1
 	if mpv.Process != nil {
@@ -46,7 +46,7 @@ func (mpv *MPV) restartProcess() error {
 	cmd.Stderr = os.Stderr
 	log.Println("starting mpv process")
 	if err := cmd.Start(); err != nil {
-		log.Println("Error: mpvdaemon.Run: ", err)
+		log.Println("Error 1b2b2f70-d75c-4ee4-b977-95f7272f72e9: mpvdaemon.Run: ", err)
 		return err
 	}
 	// Initialize Unix socket
@@ -59,14 +59,14 @@ func (mpv *MPV) restartProcess() error {
 	for i := 100; (err != nil || i == 100) && i >= 0; i-- {
 		mpvConn, err = net.DialUnix("unix", nil, mpvUnixAddr)
 		if err != nil {
-			log.Println("Warning: InitUnixConn:", err)
+			log.Println("Warning 6b94b8d9-9992-4276-8f6f-4d1b339cb59a: could not init unix socket to mpv, trying again in 2 seconds.", err)
 			time.Sleep(2 * time.Second)
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("could not establish a unix socket connection to %s", mpvSocketPath)
+		return fmt.Errorf("84c2ca00-1df2-4af5-8bd4-9248d941ad7d: could not establish a unix socket connection to %s", mpvSocketPath)
 	} else {
-		log.Println("stablished unix socket connection")
+		log.Println("Established unix socket connection to mpv.")
 		mpv.Conn = mpvConn
 	}
 	return nil
@@ -75,7 +75,9 @@ func (mpv *MPV) restartProcess() error {
 func (mpv *MPV) runProcessSupervisor(wg *sync.WaitGroup) {
 	for {
 		if _, err := mpv.Ping(); err != nil {
+			log.Println("Error b304c2bb-a940-4a3e-979d-2939e986ed87: failed to ping MPV. restarting MPV.")
 			if err := mpv.restartProcess(); err != nil {
+				log.Println("Error c7b92229-b6b8-4800-91d6-8b8afb733d9c: failed to restart MPV. stopping gnuplex.")
 				wg.Done()
 			}
 		}

--- a/backend/mpv/mpvcmd.go
+++ b/backend/mpv/mpvcmd.go
@@ -51,10 +51,10 @@ func processMPVGetResult[T string | int | float64 | []models.Track](resBytes []b
 	var res MPVGetResult[T]
 	err = json.Unmarshal(resBytes, &res)
 	if err != nil {
-		log.Println("mpv result error", err)
+		log.Println("7b289386-c838-457d-8545-2f56bddb3746 MPV reported error in API call:", err)
 		return defaultVal, err
 	} else if res.Error != "success" {
-		log.Println("mpv result error", err)
+		log.Println("b8d14416-bbec-4297-ada8-3d13bf9c6e79 MPV reported error in API Call:", err)
 		return defaultVal, errors.New(res.Error)
 	}
 	return res.Data, nil
@@ -68,10 +68,10 @@ func processMPVSetResult(resBytes []byte, err error) error {
 	var res MPVSetResult
 	err = json.Unmarshal(resBytes, &res)
 	if err != nil {
-		log.Println("mpv result error", err)
+		log.Println("3989f92e-5230-4403-a60c-1ee8429c0088 MPV reported error in API call:", err)
 		return err
 	} else if res.Error != "success" {
-		log.Println("mpv result error", err)
+		log.Println("d1a6f614-5eb6-4fa5-aedb-31b1940cb58e MPV reported error in API call:", err)
 		return errors.New(res.Error)
 	}
 	return nil


### PR DESCRIPTION
# v1.44 - Debug logging and endpoint

- more debug logging. e.g. countdown of times until restart. eventual goal: make
  it easier to isolate source of crash, see what's causing crash
- `/build` endpoint with build info. eventual goal: every little change
  shouldn't need to be a version bump. and auto-update